### PR TITLE
Add compatibility with Next.js / Typescript

### DIFF
--- a/src/components/Wheel/index.tsx
+++ b/src/components/Wheel/index.tsx
@@ -24,7 +24,7 @@ import {
 import { WheelData } from './types';
 import WheelCanvas from '../WheelCanvas';
 
-interface Props {
+export interface WheelProps {
   mustStartSpinning: boolean;
   prizeNumber: number;
   data: WheelData[];
@@ -68,7 +68,7 @@ export const Wheel = ({
   perpendicularText = false,
   textDistance = DEFAULT_TEXT_DISTANCE,
   spinDuration = DEFAULT_SPIN_DURATION,
-}: Props): JSX.Element | null => {
+}: WheelProps): JSX.Element | null => {
   const [wheelData, setWheelData] = useState<WheelData[]>([...data]);
   const [startRotationDegrees, setStartRotationDegrees] = useState(0);
   const [finalRotationDegrees, setFinalRotationDegrees] = useState(0);


### PR DESCRIPTION
... so we can leverage Next.js `dynamic()` without throwing unknown types errors. We'll do something like this to use the wheel within a component :

```
const Wheel = dynamic<WheelProps>(
    () => import('react-custom-roulette').then(mod => mod.Wheel),
    { ssr: false }
)
```

Kinda fixes https://github.com/effectussoftware/react-custom-roulette/issues/57.

We might even consider adding explainations into the README.